### PR TITLE
Add --recurse-submodules to git clone command in gitCheckout

### DIFF
--- a/libexec/gitCheckout
+++ b/libexec/gitCheckout
@@ -650,7 +650,7 @@ sub verified_github_url {
 # Usage: clone_repo($url, $destination)
 sub clone_repo {
   my ($url, $destination, @git_args) = @_;
-  my @clone_cmd = (qw(git clone), @git_args, $url, $destination);
+  my @clone_cmd = (qw(git clone --recurse-submodules), @git_args, $url, $destination);
   if ($options->{"dry-run"}) {
     report(sprintf("Would execute command %s.", join(" ", @clone_cmd)),
            -level => "INFO");


### PR DESCRIPTION
We would like to have at least one or two git submodules inside `sbncode` for code that exists independently (and might be used by others). The problem is that currently `mrb g sbncode` runs `git clone` and does not clone the submodules (you end up with empty folders). This can be fixed with a simple addition to the `git clone` command.

`git clone --recurse-submodules` should do a normal `git clone` but also automatically initialize and clone all submodules in the repository. Please see [the documentation](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---recurse-submodulesltpathspecgt) for more details on this option.

I edited the script `gitCheckout` to add this option to the `git clone` command. It is a straightforward change, but I am not sure how to properly build and source a custom `mrb` so I wasn't able to properly test it yet... Please let me know if you have any concerns or if there is a better way to do this!

